### PR TITLE
Add option to disable presence when any activity is detected

### DIFF
--- a/LastFMRichPresence.plugin.js
+++ b/LastFMRichPresence.plugin.js
@@ -389,7 +389,7 @@ Please visit <a href="https://github.com/dimdenGD/LastFMRichPresence" target="_b
         ytbtnEl.value = this.settings.youtubeButton ? "true" : "false";
         assetEl.value = this.settings.assetIcon ? "true" : "false";
         artistbeforeEl.value = this.settings.artistBeforeAlbum ? "true" : "false";
-        disableactEl.value = this.settings.artistBeforeAlbum ? "true" : "false";
+        disableactEl.value = this.settings.disableWhenActivity ? "true" : "false";
         let updateKey = () => {
             this.settings.lastFMKey = keyEl.value;
             this.updateSettings();


### PR DESCRIPTION
Added an option to disable presence when any other activity is detected. This is useful for e.g. games. Moved the checks to updateData, otherwise if you switch these options on while the presence is active it will remain stuck and not update. Also fixed the version shown in the plugin menu.