### PR TITLE
Fix large_image error (activity.assets undefined)

### DIFF
--- a/LastFMRichPresence.plugin.js
+++ b/LastFMRichPresence.plugin.js
@@ -522,9 +522,10 @@ class Constants {
           start: Date.now(),
         };
       }
-  
+
+      activity.assets = {};
+
       if (this.settings.assetIcon) {
-        activity.assets = {};
         activity.assets.small_image = await Switches.getSmallImage(
           this.trackData
         );


### PR DESCRIPTION
This fixes the activity.assets undefined error when the show asset option is off.